### PR TITLE
Add Tesseract-API batch crafter compat

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,16 +25,16 @@ repositories {
         }
     }
 
-    // for MI
-    exclusiveContent {
-        forRepository {
-            maven {
-                name = "Modrinth"
-                url = "https://api.modrinth.com/maven"
-            }
-        }
-        filter {
-            includeGroup "maven.modrinth"
+    maven {
+        name "Modmaven"
+        url "https://modmaven.dev"
+        content {
+            // GrandPower
+            includeGroup "dev.technici4n"
+            // Modern Industrialization
+            includeGroup "aztech"
+            // Tesseract
+            includeGroup "net.swedz"
         }
     }
 
@@ -151,9 +151,12 @@ sourceSets.main.resources { srcDir 'src/generated/resources' }
 
 dependencies {
     implementation "me.shedaniel.cloth:cloth-config-neoforge:${project.cloth_config_version}"
-    implementation("maven.modrinth:modern-industrialization:${project.mi_version}")
+    implementation "aztech:Modern-Industrialization:${project.mi_version}"
 
     compileOnly("dev.latvian.mods:kubejs-neoforge:${project.kubejs_version}")
+
+    implementation "net.swedz:tesseract-api-neoforge:${project.tesseract_version}-${minecraft_version}"
+    implementation "net.swedz:extended-industrialization:${project.ei_version}-${minecraft_version}"
 
     // Example mod dependency with JEI
     // The JEI API is declared for compile time use, while the full JEI artifact is used at runtime

--- a/build.gradle
+++ b/build.gradle
@@ -156,7 +156,11 @@ dependencies {
     compileOnly("dev.latvian.mods:kubejs-neoforge:${project.kubejs_version}")
 
     implementation "net.swedz:tesseract-api-neoforge:${project.tesseract_version}-${minecraft_version}"
-    implementation "net.swedz:extended-industrialization:${project.ei_version}-${minecraft_version}"
+
+    runtimeOnly "curse.maven:emi-580555:6420931"
+    // for testing Tesseract compatibility
+    runtimeOnly "net.swedz:extended-industrialization:${project.ei_version}-${minecraft_version}"
+    runtimeOnly "curse.maven:industrialization-overdrive-1089065:7024246"
 
     // Example mod dependency with JEI
     // The JEI API is declared for compile time use, while the full JEI artifact is used at runtime

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ org.gradle.configuration-cache=true
 ## Environment Properties
 # You can find the latest versions here: https://projects.neoforged.net/neoforged/neoforge
 # The Minecraft version must agree with the Neo version to get a valid artifact
-minecraft_version=1.21.0
+minecraft_version=1.21.1
 # The Minecraft version range can use any release version of Minecraft as bounds.
 # Snapshots, pre-releases, and release candidates are not guaranteed to sort properly
 # as they do not follow standard versioning conventions.
@@ -29,6 +29,8 @@ kubejs_version=2101.7.1-build.181
 kubejs_version_range=[2101.7.1-build.181,)
 mi_version=2.3.11
 mi_version_range=[2.3.11,)
+tesseract_version=1.9.0
+ei_version=1.15.9
 ei_version_range=[1.15.0-1.21.1,)
 
 ## Mod Properties

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ minecraft_version=1.21.1
 # as they do not follow standard versioning conventions.
 minecraft_version_range=[1.21.0,1.22)
 # The Neo version must agree with the Minecraft version to get a valid artifact
-neo_version=21.1.113
+neo_version=21.1.169
 # The Neo version range can use any version of Neo as bounds
 neo_version_range=[21.1.113,)
 # The loader version range can only use the major version of FML as bounds

--- a/src/main/java/dev/thestaticvoid/mi_sound_addon/mixin/MISoundAddonMixinPlugin.java
+++ b/src/main/java/dev/thestaticvoid/mi_sound_addon/mixin/MISoundAddonMixinPlugin.java
@@ -1,0 +1,56 @@
+package dev.thestaticvoid.mi_sound_addon.mixin;
+
+import net.neoforged.fml.ModList;
+import net.neoforged.fml.loading.LoadingModList;
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+import java.util.List;
+import java.util.Set;
+
+public class MISoundAddonMixinPlugin implements IMixinConfigPlugin {
+    @Override
+    public void onLoad(String mixinPackage) {
+
+    }
+
+    @Override
+    public String getRefMapperConfig() {
+        return "";
+    }
+
+    @Override
+    public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+        if (mixinClassName.equals("dev.thestaticvoid.mi_sound_addon.mixin.compat.tesseract_api.AbstractModularCrafterComponentMixin")) {
+            return isLoaded("tesseract_api");
+        }
+        return true;
+    }
+
+    @Override
+    public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {
+
+    }
+
+    @Override
+    public List<String> getMixins() {
+        return null;
+    }
+
+    @Override
+    public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+
+    }
+
+    @Override
+    public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+
+    }
+
+    private boolean isLoaded(String modId) {
+        return modId != null && !modId.isEmpty() && ModList.get() != null ?
+                ModList.get().isLoaded(modId) :
+                LoadingModList.get().getModFileById(modId) != null;
+    }
+}

--- a/src/main/java/dev/thestaticvoid/mi_sound_addon/mixin/compat/tesseract_api/AbstractModularCrafterComponentMixin.java
+++ b/src/main/java/dev/thestaticvoid/mi_sound_addon/mixin/compat/tesseract_api/AbstractModularCrafterComponentMixin.java
@@ -1,0 +1,55 @@
+package dev.thestaticvoid.mi_sound_addon.mixin.compat.tesseract_api;
+
+import aztech.modern_industrialization.machines.IComponent;
+import aztech.modern_industrialization.machines.MachineBlockEntity;
+import aztech.modern_industrialization.machines.recipe.MachineRecipe;
+import aztech.modern_industrialization.machines.recipe.condition.MachineProcessCondition;
+import dev.thestaticvoid.mi_sound_addon.MISoundAddonConfig;
+import dev.thestaticvoid.mi_sound_addon.sound.ModSounds;
+import dev.thestaticvoid.mi_sound_addon.util.SilencedComponent;
+import dev.thestaticvoid.mi_sound_addon.util.SilencedComponentInterface;
+import net.minecraft.world.item.crafting.RecipeHolder;
+import net.swedz.tesseract.neoforge.compat.mi.component.craft.AbstractModularCrafterComponent;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+import java.util.Objects;
+
+@Mixin(AbstractModularCrafterComponent.class)
+public abstract class AbstractModularCrafterComponentMixin<R> implements IComponent.ServerOnly {
+    @Unique
+    private long mISoundAddon$lastSoundTime = 0;
+
+    @Shadow(remap = false)
+    @Final
+    protected MachineProcessCondition.Context conditionContext;
+
+    @Shadow(remap = false)
+    protected R activeRecipe;
+
+    @Inject(method = "tickRecipe", at = @At("RETURN"), locals = LocalCapture.CAPTURE_FAILHARD, remap = false)
+    private void tickRecipeInject(CallbackInfoReturnable<Boolean> cir, boolean isActive) {
+        if (MISoundAddonConfig.machineSoundsEnabled) {
+            MachineBlockEntity blockEntity = this.conditionContext.getBlockEntity();
+            SilencedComponent silencedState = ((SilencedComponentInterface) blockEntity).mISoundAddon$getSilencedState();
+            if (silencedState.silenced) return;
+            long currentGameTime = Objects.requireNonNull(blockEntity.getLevel()).getGameTime();
+
+            if (isActive && this.activeRecipe != null) {
+                @SuppressWarnings("unchecked")
+                RecipeHolder<MachineRecipe> recipeHolder = (RecipeHolder<MachineRecipe>) this.activeRecipe;
+
+                if (currentGameTime > mISoundAddon$lastSoundTime + ModSounds.getDuration(recipeHolder.value())) {
+                    mISoundAddon$lastSoundTime = currentGameTime;
+                    ModSounds.playSound(blockEntity, recipeHolder.value());
+                }
+            }
+        }
+    }
+}

--- a/src/main/resources/mi_sound_addon.mixins.json
+++ b/src/main/resources/mi_sound_addon.mixins.json
@@ -2,6 +2,7 @@
   "required": true,
   "minVersion": "0.8",
   "package": "dev.thestaticvoid.mi_sound_addon.mixin",
+  "plugin": "dev.thestaticvoid.mi_sound_addon.mixin.MISoundAddonMixinPlugin",
   "compatibilityLevel": "JAVA_8",
   "refmap": "mi_sound_addon.refmap.json",
   "mixins": [
@@ -9,7 +10,8 @@
     "NuclearReactorMultiblockBlockEntityMixin",
     "PipeBlockMixin",
     "ReplicatorMachineBlockEntityMixin",
-    "TickRecipeMixin"
+    "TickRecipeMixin",
+    "compat.tesseract_api.AbstractModularCrafterComponentMixin"
   ],
   "client": [
   ],


### PR DESCRIPTION
Adds compatibility for batch crafting machines from EI/IO and any other mods that use Tesseract-API for their batch crafting machines.

Tested to work with PA/MPA, Large Electric Furnace, Large Electric Macerator.
Does not add new sounds to any EI/IO machines which don't use a recipe type that already has a sound assigned to them.