### PR TITLE
Fix machines added by addons not getting sounds registered anymore

### DIFF
--- a/src/main/java/dev/thestaticvoid/mi_sound_addon/MISoundAddon.java
+++ b/src/main/java/dev/thestaticvoid/mi_sound_addon/MISoundAddon.java
@@ -9,6 +9,7 @@ import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.fml.config.ModConfig;
+import net.neoforged.fml.event.lifecycle.FMLConstructModEvent;
 import org.slf4j.Logger;
 
 @Mod(MISoundAddon.MOD_ID)
@@ -24,10 +25,13 @@ public class MISoundAddon {
         KubeJSProxy.checkThatKubeJsIsLoaded();
 
         ModItems.init(modEventBus);
-        ModSounds.init(modEventBus);
 
         modContainer.registerConfig(ModConfig.Type.COMMON, MISoundAddonConfig.CONFIG_SPEC);
-        KubeJSProxy.instance.fireSoundModificationsEvent();
+        // Must be done after all mods are constructed so that sounds for machines added by addons can be registered too
+        modEventBus.addListener(FMLConstructModEvent.class, (event) -> event.enqueueWork(() -> {
+            ModSounds.init(modEventBus);
+            KubeJSProxy.instance.fireSoundModificationsEvent();
+        }));
 
         LOGGER.info("Modern Industrialization Sound Addon initialized.");
     }


### PR DESCRIPTION
Due to concurrency issues, I had to change in Tesseract API when recipe types are inserted into MI's `MIMachineRecipeTypes#recipeTypes` list to immediately after all mods have been constructed. This caused MI Sound Addon to stop seeing addon machine recipe types on initialization.